### PR TITLE
Add ::dotWrite method

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,84 @@ ArrayUtility::dotRead($array, "a.very.deep.hole")
 "with a prize at the bottom"
 ```
 
+### dotWrite
+*(array $array, $property, $value)*
+
+Original array:
+
+```php
+$array = [
+    "a"=>[
+        "very"=>[
+            "deep"=>[
+                "hole"=>"with a prize at the bottom"
+            ]
+        ]
+    ],
+    "i"=>[
+        "like"=>"candy"
+    ]
+]
+```
+
+Mutate existing properties:
+
+```php
+ArrayUtility::dotWrite($array, "a.very.deep.hole", "no prize!");
+ArrayUtility::dotWrite($array, "i.like", ["carrots","broccoli"]);
+```
+
+Array is now:
+
+```php
+$array = [
+    "a"=>[
+        "very"=>[
+            "deep"=>[
+                "hole"=>"no prize!"
+            ]
+        ]
+    ],
+    "i"=>[
+        "like"=>["carrots","broccoli"]
+    ]
+]
+```
+
+Set new properties:
+
+```php
+ArrayUtility::dotWrite($array, "a.very.shallow.hole", "that may contain a prize!");
+ArrayUtility::dotWrite($array, "i.also.like", "blue skies");
+```
+
+Array is now:
+
+```php
+$array = [
+    "a"=>[
+        "very"=>[
+            "deep"=>[
+                "hole"=>"no prize!"
+            ]
+        ]
+    ],
+    "a"=>[
+        "very"=>[
+            "shallow"=>[
+                "hole"=>"that may contain a prize!"
+            ]
+        ]
+    ],
+    "i"=>[
+        "like"=>["carrots","broccoli"]
+        "also"=>[
+            "like"=>"blue skies"
+        ]
+    ]
+]
+```
+
 ### flatten / inflate
 *(array $array)*
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "bkvfoundry/utility-belt",
   "description": "A set of helpful utilities for working with data, collections (arrays of arrays) and arrays in php",
-  "keywords":["collection","filter","dot read","nested read","dot syntax", "map recursive","utility","utilities"],
+  "keywords":["collection","filter","array","dot read","nested read","dot syntax", "map recursive","utility","utilities"],
   "autoload": {
     "psr-4":{
       "BkvFoundry\\UtilityBelt\\":"src/"

--- a/src/ArrayUtility.php
+++ b/src/ArrayUtility.php
@@ -98,17 +98,17 @@ class ArrayUtility
 
 	/**
 	 * Read a value from a nested array using a single string
-	 * @param array $array
-	 * @param string $key The read key e.g. "level1.level2.key"
-	 * @param mixed $default_value Default value
+	 * @param array  $array
+	 * @param string $readKey       The read key e.g. "level1.level2.key"
+	 * @param mixed  $default_value Default value
 	 * @return mixed|null The value from the array or null
 	 */
-	public static function dotRead(array $array = null, $key, $default_value = null)
+	public static function dotRead(array $array = null, $readKey, $default_value = null)
 	{
 		if (!is_array($array)) {
 			return $default_value;
 		}
-		$keys = explode(".", $key);
+		$keys = explode('.', $readKey);
 		$value = $array;
 		foreach ($keys as $key) {
 			if (!is_array($value) || !isset($value[ $key ])) {
@@ -119,12 +119,48 @@ class ArrayUtility
 		}
 
 		//Get a default value
-		if (!isset($value) && isset($default_value)) {
+		if ($value === null && $default_value !== null) {
 			return $default_value;
 		}
 
 		return $value;
 	}
+
+    /**
+     * Write a value to a nested array
+     * @param array  $array
+     * @param string $writeKey The write key e.g. "level1.level2.key"
+     * @param mixed  $value    Value to write
+     * @return bool  Returns true if write was successful
+     */
+    public static function dotWrite(array &$array, $writeKey, $value = null)
+    {
+        if (!is_array($array)) {
+            return false;
+        }
+
+        // Start value
+        $ref = &$array;
+
+        // Sequentially pull each key and traverse through the array
+        $keys = explode('.', $writeKey);
+        while (($key = array_shift($keys)) !== null) {
+            $hasMoreKeys = \count($keys) > 0;
+            if ($hasMoreKeys) {
+                if (!\array_key_exists($key, $ref)) {
+                    // Prepare the array
+                    $ref[$key] = [];
+                }
+                $ref = &$ref[$key];
+                continue;
+            }
+
+            // Last key
+            $ref[$key] = $value;
+        }
+
+        return true;
+    }
 
 	/**
 	 * Dot read multiple properties

--- a/src/ArrayUtility.php
+++ b/src/ArrayUtility.php
@@ -162,6 +162,29 @@ class ArrayUtility
         return true;
     }
 
+    /**
+     * Read a value from a nested array using a single string
+     * @param array  $array
+     * @param string $findKey The key to find e.g. "level1.level2.key"
+     * @return boolean True if the key exists
+     */
+    public static function dotExists(array $array = null, $findKey)
+    {
+        if (!is_array($array)) {
+            return false;
+        }
+        $keys = explode('.', $findKey);
+        $value = $array;
+        foreach ($keys as $key) {
+            if (!is_array($value) || !array_key_exists($key, $value)) {
+               return false;
+            }
+            $value = $value[ $key ];
+        }
+
+        return true;
+    }
+
 	/**
 	 * Dot read multiple properties
 	 * @param array $array

--- a/src/ArrayUtility.php
+++ b/src/ArrayUtility.php
@@ -127,22 +127,35 @@ class ArrayUtility
 	}
 
     /**
-     * Write a value to a nested array
+     * Write a value to a nested array and return the new array
      * @param array  $array
      * @param string $writeKey The write key e.g. "level1.level2.key"
      * @param mixed  $value    Value to write
-     * @return bool  Returns true if write was successful
+     * @return array|bool Returns a new array containing the value (or boolean false on failure)
      */
-    public static function dotWrite(array &$array, $writeKey, $value = null)
+    public static function dotWrite(array $array = null, $writeKey, $value = null)
     {
         if (!is_array($array)) {
             return false;
         }
 
-        // Start value
-        $ref = &$array;
+        // Mutate our array copy (copied in function invocation)
+        static::dotMutate($array, $writeKey, $value);
 
+        return $array;
+    }
+
+    /**
+     * Writes a value to a nested array by mutating the array.
+     * @param array  $array
+     * @param string $writeKey The write key e.g. "level1.level2.key"
+     * @param mixed  $value    Value to write
+     * @return void
+     */
+    public static function dotMutate(array &$array, $writeKey, $value = null)
+    {
         // Sequentially pull each key and traverse through the array
+        $ref = &$array;
         $keys = explode('.', $writeKey);
         while (($key = array_shift($keys)) !== null) {
             $hasMoreKeys = \count($keys) > 0;
@@ -158,15 +171,13 @@ class ArrayUtility
             // Last key
             $ref[$key] = $value;
         }
-
-        return true;
     }
 
     /**
-     * Read a value from a nested array using a single string
+     * Determine if a key exists within a nested array.
      * @param array  $array
      * @param string $findKey The key to find e.g. "level1.level2.key"
-     * @return boolean True if the key exists
+     * @return boolean True if the key exists (even if the value is null)
      */
     public static function dotExists(array $array = null, $findKey)
     {

--- a/tests/Actual/ArrayUtilityTest.php
+++ b/tests/Actual/ArrayUtilityTest.php
@@ -114,28 +114,7 @@ class ArrayUtilityTest extends TestCase
 		$this->assertEquals("default value", ArrayUtility::dotRead($array, "c.cc.ccc", "default value"));
 	}
 
-	public function testThatADeepPropertyCanBeWritten()
-	{
-        // Setup source array
-        $array = [
-            'a' => [
-                'aa' => 'aa value',
-                'bb' => [
-                    'aaa' => 'aaa value'
-                ]
-            ]
-        ];
-
-        // Change existing value
-        ArrayUtility::dotWrite($array, 'a.aa', 'changed aa value');
-        $this->assertEquals('changed aa value', $array['a']['aa']);
-
-        // Set non-existing value
-        ArrayUtility::dotWrite($array, 'xx.yy', 'xx.yy value');
-        $this->assertEquals('xx.yy value', ArrayUtility::dotRead($array, 'xx.yy'));
-	}
-
-    public function testThatCanTextExistenceOfADeepProperty()
+    public function testExistenceOfADeepProperty()
     {
         // Setup source array
         $array = [
@@ -158,6 +137,50 @@ class ArrayUtilityTest extends TestCase
         $this->assertTrue(ArrayUtility::dotExists($array, 'a.xx.yy'));
         $this->assertFalse(ArrayUtility::dotExists($array, 'zzz'));
     }
+
+    public function testThatADeepPropertyCanBeWritten()
+    {
+        // Setup source array
+        $origArray = [
+            'a' => [
+                'aa' => 'aa value',
+                'bb' => [
+                    'aaa' => 'aaa value'
+                ]
+            ]
+        ];
+
+        // Change existing value
+        $array = ArrayUtility::dotWrite($origArray, 'a.aa', 'changed aa value');
+        $this->assertEquals('changed aa value', $array['a']['aa']);
+        $this->assertEquals('aa value', $origArray['a']['aa']);
+
+        // Set non-existing value
+        $array = ArrayUtility::dotWrite($array, 'xx.yy', 'xx.yy value');
+        $this->assertEquals('xx.yy value', ArrayUtility::dotRead($array, 'xx.yy'));
+        $this->assertFalse(ArrayUtility::dotExists($origArray, 'xx.yy'));
+    }
+
+	public function testThatADeepPropertyCanBeMutated()
+	{
+        // Setup source array
+        $array = [
+            'a' => [
+                'aa' => 'aa value',
+                'bb' => [
+                    'aaa' => 'aaa value'
+                ]
+            ]
+        ];
+
+        // Change existing value
+        ArrayUtility::dotMutate($array, 'a.aa', 'changed aa value');
+        $this->assertEquals('changed aa value', $array['a']['aa']);
+
+        // Set non-existing value
+        ArrayUtility::dotMutate($array, 'xx.yy', 'xx.yy value');
+        $this->assertEquals('xx.yy value', ArrayUtility::dotRead($array, 'xx.yy'));
+	}
 
 	public function testThatAssociativeArrayCanBeDetected()
 	{

--- a/tests/Actual/ArrayUtilityTest.php
+++ b/tests/Actual/ArrayUtilityTest.php
@@ -114,9 +114,25 @@ class ArrayUtilityTest extends TestCase
 		$this->assertEquals("default value", ArrayUtility::dotRead($array, "c.cc.ccc", "default value"));
 	}
 
-	public function testDotReadCanHandleNull()
+	public function testThatADeepPropertyCanBeWritten()
 	{
-		$this->assertEquals('test_return', ArrayUtility::dotRead(null, 'test.key', 'test_return'));
+        // Setup source array
+        $array = [
+            'a' => [
+                'aa' => 'aa value',
+                'bb' => [
+                    'aaa' => 'aaa value'
+                ]
+            ]
+        ];
+
+        // Change existing value
+        ArrayUtility::dotWrite($array, 'a.aa', 'changed aa value');
+        $this->assertEquals('changed aa value', $array['a']['aa']);
+
+        // Set non-existing value
+        ArrayUtility::dotWrite($array, 'xx.yy', 'xx.yy value');
+        $this->assertEquals('xx.yy value', ArrayUtility::dotRead($array, 'xx.yy'));
 	}
 
 	public function testThatAssociativeArrayCanBeDetected()

--- a/tests/Actual/ArrayUtilityTest.php
+++ b/tests/Actual/ArrayUtilityTest.php
@@ -135,6 +135,30 @@ class ArrayUtilityTest extends TestCase
         $this->assertEquals('xx.yy value', ArrayUtility::dotRead($array, 'xx.yy'));
 	}
 
+    public function testThatCanTextExistenceOfADeepProperty()
+    {
+        // Setup source array
+        $array = [
+            'a' => [
+                'aa' => 'aa value',
+                'bb' => [
+                    'aaa' => 'aaa value'
+                ],
+                'xx' => [
+                    'yy' => null,
+                ]
+            ]
+        ];
+
+        $this->assertTrue(ArrayUtility::dotExists($array, 'a'));
+        $this->assertTrue(ArrayUtility::dotExists($array, 'a.aa'));
+        $this->assertFalse(ArrayUtility::dotExists($array, 'bb'));
+        $this->assertTrue(ArrayUtility::dotExists($array, 'a.bb.aaa'));
+        // Null value should still return true
+        $this->assertTrue(ArrayUtility::dotExists($array, 'a.xx.yy'));
+        $this->assertFalse(ArrayUtility::dotExists($array, 'zzz'));
+    }
+
 	public function testThatAssociativeArrayCanBeDetected()
 	{
 		$assoc_array = [


### PR DESCRIPTION
Added new method for mutating arrays with depth based keys:
`ArrayUtility::dotWrite($array, $key, $value)`

Added new method for testing existence even when the value is null:
`ArrayUtility::dotExists($array, $key)`

Included:
- Tests
- Updated README